### PR TITLE
fix: complete org rename f5xc-salesdemos -> f5-sales-demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@
 
 ### Added
 
-- Initial release: 11 LSP plugins migrated from f5xc-salesdemos/marketplace
+- Initial release: 11 LSP plugins migrated from f5-sales-demo/marketplace
 - bash-lsp, css-lsp, eslint-lsp, html-lsp, json-lsp, markdown-lsp, mdx-lsp, terraform-lsp, toml-lsp, tsgo-lsp, yaml-lsp
 - Full CI/CD pipeline, validation, and release automation


### PR DESCRIPTION
Closes #40

Replaces stale `f5xc-salesdemos` references with `f5-sales-demo` (org rename cleanup; clean break, pre-release). `git grep f5xc-salesdemos` now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)