### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -4,7 +4,7 @@
     "xcsh": ["biome.json", "LICENSE", ".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/super-linter.yml"],
     "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
-    "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],
+    "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
     "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
     "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     permissions:
       contents: write # fallback GITHUB_TOKEN must be able to complete the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -70,7 +70,7 @@ jobs:
         startsWith(github.head_ref, 'auto-generate/') ||
         startsWith(github.head_ref, 'autoresearch/') ||
         (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
-    uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     permissions:
       contents: read # inspect the same-repository pull request
       pull-requests: write # publish the reusable review result

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     permissions:
       contents: write # merge the validated Dependabot update
       pull-requests: write # approve and enable auto-merge

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -25,14 +25,14 @@ concurrency:
 
 jobs:
   enforce-settings:
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     permissions:
       contents: read # read documentation sources
       packages: read # pull the fleet documentation builder image

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -20,7 +20,7 @@ jobs:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN (always available to a called workflow), so passing repository
     # secrets would hand over more than it needs.
-    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     permissions:
       issues: read # verify that the referenced tracking issue exists
       pull-requests: write # publish the required check result and comment

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@4796ba660860c59b27aedd52fb30ed1841897a16
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -35,4 +35,4 @@ jobs:
     # in a job-level `if:`. An unset variable evaluates false, so this fails safe
     # toward not spending money.
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@4796ba660860c59b27aedd52fb30ed1841897a16

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Full report first (all severities) into the run summary, so low and
       # informational findings are visible and countable without failing the job.

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ venv/
 env/
 ENV/
 .venv/
+# A directory-only pattern does not match a worktree's virtual-environment
+# symlink, so protect both forms from accidental staging.
+.venv
 
 # Test coverage
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -268,11 +268,16 @@ repos:
         name: "i18n: regenerate translations for staged English docs"
         entry: >-
           bash -c
-          'if [ "${TRANSLATIONS_ENABLED:-}" != "true" ];
-          then echo "[i18n] translations suspended (TRANSLATIONS_ENABLED unset) — skipping generation; see CONTRIBUTING.md.";
-          elif command -v docs-translate >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ];
-          then docs-translate --staged;
-          else echo "[i18n] docs-translate/ANTHROPIC_API_KEY unavailable — skipping."; fi'
+          'case "${TRANSLATIONS_ENABLED:-false}" in
+          false) echo "[i18n] translations suspended — skipping generation; see CONTRIBUTING.md." ;;
+          true)
+          if ! command -v docs-translate >/dev/null 2>&1;
+          then echo "[i18n] TRANSLATIONS_ENABLED=true requires docs-translate." >&2; exit 1;
+          elif [ -z "${ANTHROPIC_API_KEY:-}" ];
+          then echo "[i18n] TRANSLATIONS_ENABLED=true requires ANTHROPIC_API_KEY." >&2; exit 1;
+          else exec docs-translate --staged; fi ;;
+          *) echo "[i18n] TRANSLATIONS_ENABLED must be true or false." >&2; exit 1 ;;
+          esac'
         language: system
         files: ^docs/en/.*\.mdx?$
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,8 +311,8 @@ reviewer left behind.
    check that is never emitted. An unconditional job removes that whole class of failure — after this,
    `TRANSLATIONS_ENABLED` governs only local generation, which fails visibly and cheaply.
 
-   `tests/test-translation-suspension.sh` keys section 1 on the `SUSPENDED:` marker, so leaving it in
-   place fails the guard the moment the context comes back.
+   docs-control's `tests/test-translation-suspension.sh` keys section 1 on the `SUSPENDED:` marker,
+   so leaving it in place fails the guard the moment the context comes back.
 4. Confirm the audit actually reports on **every governed repository that receives the workflow**, not
    on one pull request. Three traps here, all of them load-bearing:
 

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,10 +1,7 @@
 ---
 rules:
-  # SHA-pinning is enforced by convention and by ref-version-mismatch.
-  # This rule's heuristic flags some valid SHA pins; redundant with
-  # the stricter rule we already rely on.
-  unpinned-uses:
-    disable: true
+  # Remote actions and reusable workflows are commit-pinned. Keep
+  # unpinned-uses active so any mutable ref fails the security audit.
   # Low-confidence finding;
   # persist-credentials: false not required
   # for our use case


### PR DESCRIPTION
Closes #120

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/github-pages-deploy.yml
- .github/workflows/enforce-repo-settings.yml
- .github/workflows/require-linked-issue.yml
- .github/workflows/super-linter.yml
- .github/workflows/translation-audit.yml
- CONTRIBUTING.md
- .gitignore
- .pre-commit-config.yaml
- .github/workflows/dependabot-auto-merge.yml
- .github/workflows/auto-merge.yml
- zizmor.yaml
- .claude/governance.json
- .github/workflows/code-review.yml
- .github/workflows/workflow-security-audit.yml