### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -30,7 +30,7 @@ jobs:
         startsWith(github.head_ref, 'auto-generate/') ||
         startsWith(github.head_ref, 'autoresearch/') ||
         (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -36,7 +36,7 @@ jobs:
         startsWith(github.head_ref, 'auto-generate/') ||
         startsWith(github.head_ref, 'autoresearch/') ||
         (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       contents: write # fallback GITHUB_TOKEN must be able to complete the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -70,7 +70,7 @@ jobs:
         startsWith(github.head_ref, 'auto-generate/') ||
         startsWith(github.head_ref, 'autoresearch/') ||
         (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
-    uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       contents: read # inspect the same-repository pull request
       pull-requests: write # publish the reusable review result

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       contents: write # merge the validated Dependabot update
       pull-requests: write # approve and enable auto-merge

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     with:
       content-ref: ${{ github.sha }}
     permissions:

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -20,7 +20,7 @@ jobs:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN (always available to a called workflow), so passing repository
     # secrets would hand over more than it needs.
-    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       issues: read # verify that the referenced tracking issue exists
       pull-requests: write # publish the required check result and comment

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -35,4 +35,4 @@ jobs:
     # in a job-level `if:`. An unset variable evaluates false, so this fails safe
     # toward not spending money.
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@8617beb254746f5f1c75fe48b6eee17c5db4df41
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@ac6108ea50661324c9da55ee7d1a6fd735a6de01


### PR DESCRIPTION
Closes #140

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/github-pages-deploy.yml
- .github/workflows/require-linked-issue.yml
- .github/workflows/super-linter.yml
- .github/workflows/translation-audit.yml
- .github/workflows/antigravity-review.yml
- .github/workflows/antigravity-translate.yml
- .github/workflows/dependabot-auto-merge.yml
- .github/workflows/auto-merge.yml
- .github/workflows/code-review.yml