### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Detect version changes and create releases
         env:

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   release:
     name: Create plugin releases
-    runs-on: [self-hosted, Linux, X64, marketplace-claude-code]
+    runs-on: [self-hosted, Linux, X64, marketplace-claude-code, ubuntu-24.04]
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -18,10 +18,10 @@ concurrency:
 jobs:
   release:
     name: Create plugin releases
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, marketplace-claude-code]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
 

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install jq
         run: |

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -28,10 +28,10 @@ concurrency:
 jobs:
   validate:
     name: Validate plugin manifests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, marketplace-claude-code]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install jq
         run: |

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   validate:
     name: Validate plugin manifests
-    runs-on: [self-hosted, Linux, X64, marketplace-claude-code]
+    runs-on: [self-hosted, Linux, X64, marketplace-claude-code, ubuntu-24.04]
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null


### PR DESCRIPTION
Closes #222

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.