### PR TITLE
docs: verify linked-issue check

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+<!-- Linked-issue verification marker: #290. -->


### PR DESCRIPTION
Closes #290\n\nAdds the authorized inert documentation marker to verify the canonical linked-issue PR check.