### PR TITLE
ci(runners): migrate workflows to repository-scoped ARC

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -13,7 +13,8 @@
       ".github/workflows/semgrep.yml",
       ".github/workflows/translation-audit.yml",
       ".github/workflows/workflow-security-audit.yml",
-      ".github/workflows/require-linked-issue.yml"
+      ".github/workflows/require-linked-issue.yml",
+      ".github/workflows/github-pages-deploy.yml"
     ],
     "xcsh-action": ["README.md"],
     "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -29,6 +29,8 @@ self-hosted-runner:
     - fixture
     - i18n-core
     - macos-15-intel
+    - managed-container-build
+    - managed-socketless
     - marketplace
     - marketplace-claude-code
     - mcn

--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -10,40 +10,7 @@
     "target_version": "29.7.2"
   },
   "dispatcher": {
-    "repositories": [
-      "f5-sales-demo/administration",
-      "f5-sales-demo/api-protection",
-      "f5-sales-demo/api-specs",
-      "f5-sales-demo/api-specs-enriched",
-      "f5-sales-demo/apt-repo",
-      "f5-sales-demo/bot-advanced",
-      "f5-sales-demo/bot-standard",
-      "f5-sales-demo/cdn",
-      "f5-sales-demo/cdn-simulator",
-      "f5-sales-demo/console",
-      "f5-sales-demo/csd",
-      "f5-sales-demo/ddos",
-      "f5-sales-demo/demo-resource-template",
-      "f5-sales-demo/demo-resources",
-      "f5-sales-demo/devcontainer",
-      "f5-sales-demo/dns",
-      "f5-sales-demo/docs-control",
-      "f5-sales-demo/marketplace",
-      "f5-sales-demo/marketplace-claude-code",
-      "f5-sales-demo/mcn",
-      "f5-sales-demo/nginx",
-      "f5-sales-demo/observability",
-      "f5-sales-demo/origin-server",
-      "f5-sales-demo/starlight-mega-menu",
-      "f5-sales-demo/terraform-provider-xcsh",
-      "f5-sales-demo/traffic-generator",
-      "f5-sales-demo/vscode-xcsh",
-      "f5-sales-demo/waf",
-      "f5-sales-demo/was",
-      "f5-sales-demo/webapp-api-protection",
-      "f5-sales-demo/xcsh-action",
-      "f5-sales-demo/xcsh-chrome-extension"
-    ],
+    "repositories": [],
     "memory": "48g",
     "cpus": "18",
     "standard_runners": 3,
@@ -589,56 +556,228 @@
   },
   "repositories": {
     "f5-sales-demo/administration": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/api-protection": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/api-specs": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/api-specs-enriched": {
       "runner": {
-        "profiles": ["ubuntu-24.04", "ubuntu-24.04-secondary", "container-build"]
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
       }
     },
     "f5-sales-demo/apt-repo": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/bot-advanced": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/bot-standard": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/cdn": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/cdn-simulator": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/console": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/csd": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/ddos": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/demo-resource-template": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/demo-resources": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/devcontainer": {
       "runner": {
-        "profiles": ["ubuntu-24.04", "container-build"]
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
       }
     },
     "f5-sales-demo/dns": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/docs": {
       "runner": {
@@ -658,7 +797,16 @@
     },
     "f5-sales-demo/docs-control": {
       "runner": {
-        "profiles": ["ubuntu-24.04", "ubuntu-24.04-secondary", "automation", "container-build"]
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
       }
     },
     "f5-sales-demo/docs-icons": {
@@ -686,22 +834,88 @@
       }
     },
     "f5-sales-demo/marketplace": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/marketplace-claude-code": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/mcn": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/nginx": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/observability": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/origin-server": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/starlight-llms-txt": {
       "runner": {
@@ -712,22 +926,88 @@
       }
     },
     "f5-sales-demo/starlight-mega-menu": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/traffic-generator": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/vscode-xcsh": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/waf": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/was": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/webapp-api-protection": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/xcsh": {
       "runner": {
@@ -744,14 +1024,45 @@
       }
     },
     "f5-sales-demo/xcsh-action": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/xcsh-chrome-extension": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
+      }
     },
     "f5-sales-demo/terraform-provider-xcsh": {
       "runner": {
-        "profiles": ["ubuntu-24.04", "container-build"]
+        "arc_scale_sets": {
+          "socketless": {
+            "label": "managed-socketless",
+            "profile": "ubuntu-24.04"
+          },
+          "container-build": {
+            "label": "managed-container-build",
+            "profile": "container-build"
+          }
+        }
       },
       ".github/workflows/acc-tests.yml": {
         "real-api-tests": {

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   review:
     if: vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@58ce2a9b09aa28f6a37b53c6cce445216bc46670
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: managed-socketless
     steps:
       - name: Require downstream-triggering token
         env:
@@ -54,7 +54,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@58ce2a9b09aa28f6a37b53c6cce445216bc46670
     permissions:
       contents: write # the reusable completes the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Approve and enable auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: managed-socketless
     permissions:
       contents: write # merge validated Dependabot updates
       pull-requests: write # approve pull requests and enable auto-merge

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,9 +18,11 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@58ce2a9b09aa28f6a37b53c6cce445216bc46670
     with:
       content-ref: ${{ github.sha }}
+      socketless_runner_label: managed-socketless
+      container_build_runner_label: managed-container-build
     permissions:
       contents: read # read documentation sources
       packages: read # pull the fleet documentation builder image

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   release:
     name: Create plugin releases
-    runs-on: [self-hosted, Linux, X64, marketplace-claude-code, ubuntu-24.04]
+    runs-on: managed-socketless
     permissions:
       contents: write # create GitHub releases for changed plugin versions
     steps:

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -19,7 +19,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.event.pull_request.head.ref, 'governance/reconcile-')
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: managed-socketless
     permissions:
       pull-requests: read # inspect linked issues on the current pull request
     steps:

--- a/.github/workflows/self-hosted-runner-python-uv-smoke.yml
+++ b/.github/workflows/self-hosted-runner-python-uv-smoke.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tool-cache-smoke:
     name: Validate catalogued Python and uv
-    runs-on: [self-hosted, Linux, X64, marketplace-claude-code, ubuntu-24.04]
+    runs-on: managed-socketless
     timeout-minutes: 10
     steps:
       - name: Assert private cache and immutable image boundaries

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -21,9 +21,11 @@ jobs:
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'governance/reconcile-') }}
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@58ce2a9b09aa28f6a37b53c6cce445216bc46670
     with:
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
+      socketless_runner_label: managed-socketless
+      container_build_runner_label: managed-container-build
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   audit:
     name: English-only documentation policy
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: managed-socketless
     steps:
       - name: Record suspended translation policy
         run: |

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   validate:
     name: Validate plugin manifests
-    runs-on: [self-hosted, Linux, X64, marketplace-claude-code, ubuntu-24.04]
+    runs-on: managed-socketless
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -85,7 +85,7 @@ jobs:
   audit:
     name: Audit workflows (zizmor)
     if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: managed-socketless
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/audit-runner-workflows.py
+++ b/scripts/audit-runner-workflows.py
@@ -35,6 +35,13 @@ DEFAULT_BRANCH_DOCKER_GUARD = (
     "github.event.pull_request.head.repo.full_name == github.repository)"
 )
 TAG_ONLY_DOCKER_GUARD = "startsWith(github.ref, 'refs/tags/v')"
+SCHEDULED_DEFAULT_BRANCH_DOCKER_GUARD = (
+    "github.event_name == 'workflow_dispatch' || "
+    "github.event_name == 'schedule' || "
+    "(github.event_name == 'push' && "
+    "github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && "
+    "github.ref_protected == true)"
+)
 PAGES_DOCKER_GUARD = (
     "github.event_name == 'workflow_dispatch' || "
     "(github.event_name == 'push' && "
@@ -83,6 +90,115 @@ REUSABLE_DEFINITION_ROUTES = {
         SOCKETLESS_ROUTE_EXPRESSION,
     ),
 }
+
+
+DOCS_ARC_COHORT = frozenset(
+    f"f5-sales-demo/{name}"
+    for name in (
+        "docs",
+        "docs-builder",
+        "docs-icons",
+        "docs-theme",
+        "i18n-core",
+        "starlight-llms-txt",
+    )
+)
+MANAGED_ARC_COHORT = frozenset(
+    f"f5-sales-demo/{name}"
+    for name in (
+        "administration",
+        "api-protection",
+        "api-specs",
+        "api-specs-enriched",
+        "apt-repo",
+        "bot-advanced",
+        "bot-standard",
+        "cdn",
+        "cdn-simulator",
+        "console",
+        "csd",
+        "ddos",
+        "demo-resource-template",
+        "demo-resources",
+        "devcontainer",
+        "dns",
+        "docs-control",
+        "marketplace",
+        "marketplace-claude-code",
+        "mcn",
+        "nginx",
+        "observability",
+        "origin-server",
+        "starlight-mega-menu",
+        "terraform-provider-xcsh",
+        "traffic-generator",
+        "vscode-xcsh",
+        "waf",
+        "was",
+        "webapp-api-protection",
+        "xcsh-action",
+        "xcsh-chrome-extension",
+    )
+)
+ARC_SHARED_CONTRACTS = (
+    (
+        DOCS_ARC_COHORT,
+        {
+            "socketless": {
+                "label": "docs-socketless",
+                "profile": "ubuntu-24.04",
+            },
+            "container-build": {
+                "label": "docs-container-build",
+                "profile": "container-build",
+            },
+        },
+    ),
+    (
+        MANAGED_ARC_COHORT,
+        {
+            "socketless": {
+                "label": "managed-socketless",
+                "profile": "ubuntu-24.04",
+            },
+            "container-build": {
+                "label": "managed-container-build",
+                "profile": "container-build",
+            },
+        },
+    ),
+    (
+        frozenset({"f5-sales-demo/xcsh"}),
+        {
+            "socketless": {
+                "label": "xcsh-socketless",
+                "profile": "ubuntu-24.04",
+            },
+            "container-build": {
+                "label": "xcsh-container-build",
+                "profile": "container-build",
+            },
+        },
+    ),
+)
+RESERVED_ARC_LABELS = frozenset(
+    {
+        "docs-container-build",
+        "docs-socketless",
+        "managed-container-build",
+        "managed-socketless",
+        "xcsh-container-build",
+        "xcsh-socketless",
+    }
+)
+
+
+def expected_arc_scale_sets(repository):
+    """Return the exact shared-label contract for a governed ARC cohort."""
+    for cohort, contract in ARC_SHARED_CONTRACTS:
+        if repository in cohort:
+            return contract
+    return None
 
 
 class AuditError(ValueError):
@@ -174,19 +290,14 @@ def repository_routes(policy, repository):
             if label in profiles_by_label:
                 raise AuditError(f"duplicate ARC scale set label: {label}")
             profiles_by_label[label] = profile
-        if repository == "f5-sales-demo/xcsh":
-            expected = {
-                "socketless": {
-                    "label": "xcsh-socketless",
-                    "profile": "ubuntu-24.04",
-                },
-                "container-build": {
-                    "label": "xcsh-container-build",
-                    "profile": "container-build",
-                },
-            }
-            if scale_sets != expected:
-                raise AuditError("xcsh ARC scale set contract is invalid")
+        expected = expected_arc_scale_sets(repository)
+        if expected is not None and scale_sets != expected:
+            raise AuditError(f"{repository} ARC scale-set contract is invalid")
+        if expected is None:
+            leaked = set(profiles_by_label) & RESERVED_ARC_LABELS
+            if leaked:
+                message = "reserved ARC scale-set label escaped its cohort"
+                raise AuditError(f"{message}: {sorted(leaked)}")
         return {"kind": "arc", "profiles_by_label": profiles_by_label}
 
     allowed = runner.get("profiles", list(profiles))
@@ -339,7 +450,7 @@ def audit_docker_route(  # noqa: PLR0917
         triggers = trigger_names(workflow)
     except AuditError as exc:
         return [f"Docker-capable job has a malformed trigger: {exc}"]
-    allowed = {"pull_request", "push", "workflow_call", "workflow_dispatch"}
+    allowed = {"pull_request", "push", "schedule", "workflow_call", "workflow_dispatch"}
     if not triggers or not triggers <= allowed:
         errors.append(
             "Docker-capable jobs require a protected push, same-repository PR, or manual dispatch",
@@ -355,6 +466,8 @@ def audit_docker_route(  # noqa: PLR0917
         ) == (".github/workflows/github-pages-deploy.yml", "build")
         if pages_build:
             expected_guard = PAGES_DOCKER_GUARD
+        elif "schedule" in triggers:
+            expected_guard = SCHEDULED_DEFAULT_BRANCH_DOCKER_GUARD
         elif triggers == {"pull_request"}:
             expected_guard = PULL_REQUEST_GUARD
         elif "push" in triggers or triggers == {"workflow_call"}:

--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -25,40 +25,7 @@ DOCKER_POLICY = {
     "target_version": "29.7.2",
 }
 DISPATCHER_POLICY = {
-    "repositories": [
-        "f5-sales-demo/administration",
-        "f5-sales-demo/api-protection",
-        "f5-sales-demo/api-specs",
-        "f5-sales-demo/api-specs-enriched",
-        "f5-sales-demo/apt-repo",
-        "f5-sales-demo/bot-advanced",
-        "f5-sales-demo/bot-standard",
-        "f5-sales-demo/cdn",
-        "f5-sales-demo/cdn-simulator",
-        "f5-sales-demo/console",
-        "f5-sales-demo/csd",
-        "f5-sales-demo/ddos",
-        "f5-sales-demo/demo-resource-template",
-        "f5-sales-demo/demo-resources",
-        "f5-sales-demo/devcontainer",
-        "f5-sales-demo/dns",
-        "f5-sales-demo/docs-control",
-        "f5-sales-demo/marketplace",
-        "f5-sales-demo/marketplace-claude-code",
-        "f5-sales-demo/mcn",
-        "f5-sales-demo/nginx",
-        "f5-sales-demo/observability",
-        "f5-sales-demo/origin-server",
-        "f5-sales-demo/starlight-mega-menu",
-        "f5-sales-demo/terraform-provider-xcsh",
-        "f5-sales-demo/traffic-generator",
-        "f5-sales-demo/vscode-xcsh",
-        "f5-sales-demo/waf",
-        "f5-sales-demo/was",
-        "f5-sales-demo/webapp-api-protection",
-        "f5-sales-demo/xcsh-action",
-        "f5-sales-demo/xcsh-chrome-extension",
-    ],
+    "repositories": [],
     "memory": "48g",
     "cpus": "18",
     "standard_runners": 3,
@@ -141,6 +108,115 @@ REUSABLE_DEFINITION_ROUTES = {
         SOCKETLESS_ROUTE_EXPRESSION,
     ),
 }
+
+
+DOCS_ARC_COHORT = frozenset(
+    f"f5-sales-demo/{name}"
+    for name in (
+        "docs",
+        "docs-builder",
+        "docs-icons",
+        "docs-theme",
+        "i18n-core",
+        "starlight-llms-txt",
+    )
+)
+MANAGED_ARC_COHORT = frozenset(
+    f"f5-sales-demo/{name}"
+    for name in (
+        "administration",
+        "api-protection",
+        "api-specs",
+        "api-specs-enriched",
+        "apt-repo",
+        "bot-advanced",
+        "bot-standard",
+        "cdn",
+        "cdn-simulator",
+        "console",
+        "csd",
+        "ddos",
+        "demo-resource-template",
+        "demo-resources",
+        "devcontainer",
+        "dns",
+        "docs-control",
+        "marketplace",
+        "marketplace-claude-code",
+        "mcn",
+        "nginx",
+        "observability",
+        "origin-server",
+        "starlight-mega-menu",
+        "terraform-provider-xcsh",
+        "traffic-generator",
+        "vscode-xcsh",
+        "waf",
+        "was",
+        "webapp-api-protection",
+        "xcsh-action",
+        "xcsh-chrome-extension",
+    )
+)
+ARC_SHARED_CONTRACTS = (
+    (
+        DOCS_ARC_COHORT,
+        {
+            "socketless": {
+                "label": "docs-socketless",
+                "profile": "ubuntu-24.04",
+            },
+            "container-build": {
+                "label": "docs-container-build",
+                "profile": "container-build",
+            },
+        },
+    ),
+    (
+        MANAGED_ARC_COHORT,
+        {
+            "socketless": {
+                "label": "managed-socketless",
+                "profile": "ubuntu-24.04",
+            },
+            "container-build": {
+                "label": "managed-container-build",
+                "profile": "container-build",
+            },
+        },
+    ),
+    (
+        frozenset({"f5-sales-demo/xcsh"}),
+        {
+            "socketless": {
+                "label": "xcsh-socketless",
+                "profile": "ubuntu-24.04",
+            },
+            "container-build": {
+                "label": "xcsh-container-build",
+                "profile": "container-build",
+            },
+        },
+    ),
+)
+RESERVED_ARC_LABELS = frozenset(
+    {
+        "docs-container-build",
+        "docs-socketless",
+        "managed-container-build",
+        "managed-socketless",
+        "xcsh-container-build",
+        "xcsh-socketless",
+    }
+)
+
+
+def expected_arc_scale_sets(repository):
+    """Return the exact shared-label contract for a governed ARC cohort."""
+    for cohort, contract in ARC_SHARED_CONTRACTS:
+        if repository in cohort:
+            return contract
+    return None
 
 
 class PolicyError(ValueError):
@@ -236,19 +312,16 @@ def repository_runner_routes(workflows, profiles, default_profile, repository):
             if label in profiles_by_label:
                 raise PolicyError(f"duplicate ARC scale set label: {label}")
             profiles_by_label[label] = profile
-        if repository == "f5-sales-demo/xcsh":
-            expected = {
-                "socketless": {
-                    "label": "xcsh-socketless",
-                    "profile": "ubuntu-24.04",
-                },
-                "container-build": {
-                    "label": "xcsh-container-build",
-                    "profile": "container-build",
-                },
-            }
-            if scale_sets != expected:
-                raise PolicyError("xcsh ARC scale set contract is invalid")
+        expected = expected_arc_scale_sets(repository)
+        if expected is not None and scale_sets != expected:
+            raise PolicyError(
+                f"{repository} ARC scale-set contract is invalid"
+            )
+        if expected is None:
+            leaked = set(profiles_by_label) & RESERVED_ARC_LABELS
+            if leaked:
+                message = "reserved ARC scale-set label escaped its cohort"
+                raise PolicyError(f"{message}: {sorted(leaked)}")
         return {"kind": "arc", "profiles_by_route": profiles_by_label}
 
     allowed = runner.get("profiles", [default_profile])

--- a/tests/test-github-api-resilience.sh
+++ b/tests/test-github-api-resilience.sh
@@ -508,14 +508,14 @@ if [ -f "$watcher" ]; then
     grep -qE '\[PROGRESS\].*repository' "$watcher_collector"
   check 'Free-tier contract remains explicit' \
     grep -qF 'GitHub Free-compatible' "$watcher"
-  check 'central content reconciler uses a self-hosted runner' \
-    grep -qF 'runs-on: [self-hosted' "$content_reconciler"
+  check 'central content reconciler uses the managed socketless ARC route' \
+    grep -qF 'runs-on: managed-socketless' "$content_reconciler"
   check 'central content reconciler has an explicit job name' \
     grep -qF '    name: Reconcile fleet content' "$content_reconciler"
   check 'central content reconciler binds secrets to the repository-settings environment' \
     grep -qF '    environment: repository-settings' "$content_reconciler"
-  check 'central settings reconciler remains self-hosted, push-driven, and manually dispatchable without cron' \
-    bash -c "grep -qF 'runs-on: [self-hosted' '$settings_reconciler' && grep -qF 'push:' '$settings_reconciler' && grep -qF 'workflow_dispatch:' '$settings_reconciler' && ! grep -qF 'schedule:' '$settings_reconciler'"
+  check 'central settings reconciler remains ARC-routed, push-driven, and manually dispatchable without cron' \
+    bash -c "grep -qF 'runs-on: managed-socketless' '$settings_reconciler' && grep -qF 'push:' '$settings_reconciler' && grep -qF 'workflow_dispatch:' '$settings_reconciler' && ! grep -qF 'schedule:' '$settings_reconciler'"
   check 'central settings reconciler has an explicit job name' \
     grep -qF '    name: Reconcile fleet settings' "$settings_reconciler"
   check 'central settings reconciler binds secrets to the repository-settings environment' \


### PR DESCRIPTION
Closes #299

## Summary
- replace legacy runner routes with the exact repository-scoped ARC managed files
- route socketless work to `managed-socketless`
- route container builds to `managed-container-build`
- preserve hosted exceptions and keep Antigravity manually disabled

## Validation
- plugin manifest validation
- governed workflow security validator, runner auditor, and Zizmor
- repository shell tests