### PR TITLE
docs: add required Pages title metadata

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,5 @@
+---
+title: Marketplace Claude Code
+---
+
 <!-- Linked-issue verification marker: #290. -->


### PR DESCRIPTION
## Summary

- add the required Astro title frontmatter to docs/index.md
- preserve the linked-issue verification marker
- restore the post-cutover Pages build without weakening the shared builder

## Validation

- bash scripts/lint-mdx-prose.sh --textlint-only docs/index.md
- npx --yes markdownlint-cli@0.49.1 --config .markdownlint.json docs/index.md
- bash scripts/check-pii.sh --scope changed --mode enforce
- exact shared docs-builder image at sha256:ba96cff87c091d2f39f6ec9cf94e7036fb2cad58738bb238ff22a71e6d467e92 completed with docker --pull=never and produced a non-empty site

Closes #301
